### PR TITLE
Runtime update: InvenioRDM 8

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,15 +7,13 @@ verify_ssl = true
 check-manifest = ">=0.25"
 
 [packages]
-invenio-app-rdm = {version = "~=6.0.5", extras = ["elasticsearch7", "postgresql"]}
-
+invenio-app-rdm = {version = "~=8.0.0", extras = ["elasticsearch7", "postgresql"]}
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
 
 # Solving: https://github.com/pallets/markupsafe/issues/284
 markupsafe = "<=2.0.1"
-
 # Solving: https://github.com/ipython/ipython/issues/13554
 ipython = "<=8.0.1"
 

--- a/Pipfile
+++ b/Pipfile
@@ -5,9 +5,11 @@ verify_ssl = true
 
 [dev-packages]
 check-manifest = ">=0.25"
+# REMOVE setuptools line once celery 5.2.4 has been released.
+setuptools = ">=59.1.1,<59.7.0"
 
 [packages]
-invenio-app-rdm = {version = "~=8.0.0", extras = ["elasticsearch7", "postgresql"]}
+invenio-app-rdm = {version = "~=8.0.0", extras = ["elasticsearch7", "postgresql", "s3"]}
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
@@ -15,11 +17,11 @@ uwsgi-tools = ">=1.1.1"
 # Solving: https://github.com/pallets/markupsafe/issues/284
 markupsafe = "<=2.0.1"
 # Solving: https://github.com/ipython/ipython/issues/13554
-ipython = "<=8.0.1"
+ipython = "!=8.1.0"
 
 [requires]
 python_version = "3.8"
 
 [pipenv]
-# Needed for invenio-records>v1.5.0a1
+# Needed for invenio>v3.5.0a4 and invenio-communities
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a81c1c5e387e8f3b995907ab05f4c0317ff299fab78d938a5aee722cced946b1"
+            "sha256": "85eec31deb47f15197539a5148497c8f1b90f0a1e89115cbdff414720f914c86"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:6c0c05e9768a896d804387e20b299880fe01bc56484246b0dffe8075d6d3d847",
-                "sha256:ad842f2c3ab5c5d4861232730779c05e33db4ba880a08b85eb505e87c01095bc"
+                "sha256:29be0856ec7591c39f4e1cb10f198045d890e6e2274cf8da80cb5e721a09642b",
+                "sha256:4961248173ead7ce8a21efb3de378f13b8398e6630fab0eb258dc74a8af24c58"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.7.6"
+            "version": "==1.7.7"
         },
         "amqp": {
             "hashes": [
-                "sha256:1e5f707424e544078ca196e72ae6a14887ce74e02bd126be54b7c03c971bef18",
-                "sha256:9cd81f7b023fc04bbb108718fbac674f06901b77bfcdce85b10e2a5d0ee91be5"
+                "sha256:446b3e8a8ebc2ceafd424ffcaab1c353830d48161256578ed7a65448e601ebed",
+                "sha256:a575f4fa659a2290dc369b000cff5fea5c6be05fe3f2d5e511bcf56c7881c3ef"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==5.0.9"
+            "version": "==5.1.0"
         },
         "aniso8601": {
             "hashes": [
@@ -77,12 +77,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.4.0"
         },
-        "autosemver": {
-            "hashes": [
-                "sha256:0af1e8a9c3604545c067311f1c26403e8f0d60b5d9561c0217e14eee21c98b02"
-            ],
-            "version": "==0.5.5"
-        },
         "babel": {
             "hashes": [
                 "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9",
@@ -121,11 +115,32 @@
         },
         "black": {
             "hashes": [
-                "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3",
-                "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"
+                "sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2",
+                "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71",
+                "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6",
+                "sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5",
+                "sha256:2d6f331c02f0f40aa51a22e479c8209d37fcd520c77721c034517d44eecf5912",
+                "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866",
+                "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d",
+                "sha256:35944b7100af4a985abfcaa860b06af15590deb1f392f06c8683b4381e8eeaf0",
+                "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321",
+                "sha256:5fa1db02410b1924b6749c245ab38d30621564e658297484952f3d8a39fce7e8",
+                "sha256:6f2f01381f91c1efb1451998bd65a129b3ed6f64f79663a55fe0e9b74a5f81fd",
+                "sha256:742ce9af3086e5bd07e58c8feb09dbb2b047b7f566eb5f5bc63fd455814979f3",
+                "sha256:7835fee5238fc0a0baf6c9268fb816b5f5cd9b8793423a75e8cd663c48d073ba",
+                "sha256:8871fcb4b447206904932b54b567923e5be802b9b19b744fdff092bd2f3118d0",
+                "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5",
+                "sha256:b1a5ed73ab4c482208d20434f700d514f66ffe2840f63a6252ecc43a9bc77e8a",
+                "sha256:c8226f50b8c34a14608b848dc23a46e5d08397d009446353dad45e04af0c8e28",
+                "sha256:ccad888050f5393f0d6029deea2a33e5ae371fd182a697313bdbd835d3edaf9c",
+                "sha256:dae63f2dbf82882fa3b2a3c49c32bffe144970a573cd68d247af6560fc493ae1",
+                "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab",
+                "sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f",
+                "sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61",
+                "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==21.12b0"
+            "version": "==22.1.0"
         },
         "bleach": {
             "hashes": [
@@ -200,11 +215,11 @@
         },
         "celery": {
             "hashes": [
-                "sha256:8d9a3de9162965e97f8e8cc584c67aad83b3f7a267584fa47701ed11c3e0d4b0",
-                "sha256:9dab2170b4038f7bf10ef2861dbf486ddf1d20592290a1040f7b7a1259705d42"
+                "sha256:8aacd02fc23a02760686d63dde1eb0daa9f594e735e73ea8fb15c2ff15cb608c",
+                "sha256:e2cd41667ad97d4f6a2f4672d1c6a6ebada194c619253058b5f23704aaadaa82"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==5.1.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==5.2.3"
         },
         "certifi": {
             "hashes": [
@@ -293,11 +308,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+                "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1",
+                "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==7.1.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.4"
         },
         "click-default-group": {
             "hashes": [
@@ -329,29 +344,29 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0a817b961b46894c5ca8a66b599c745b9a3d9f822725221f0e0fe49dc043a3a3",
-                "sha256:2d87cdcb378d3cfed944dac30596da1968f88fb96d7fc34fdae30a99054b2e31",
-                "sha256:30ee1eb3ebe1644d1c3f183d115a8c04e4e603ed6ce8e394ed39eea4a98469ac",
-                "sha256:391432971a66cfaf94b21c24ab465a4cc3e8bf4a939c1ca5c3e3a6e0abebdbcf",
-                "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316",
-                "sha256:4caa4b893d8fad33cf1964d3e51842cd78ba87401ab1d2e44556826df849a8ca",
-                "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638",
-                "sha256:596f3cd67e1b950bc372c33f1a28a0692080625592ea6392987dba7f09f17a94",
-                "sha256:5d59a9d55027a8b88fd9fd2826c4392bd487d74bf628bb9d39beecc62a644c12",
-                "sha256:6c0c021f35b421ebf5976abf2daacc47e235f8b6082d3396a2fe3ccd537ab173",
-                "sha256:73bc2d3f2444bcfeac67dd130ff2ea598ea5f20b40e36d19821b4df8c9c5037b",
-                "sha256:74d6c7e80609c0f4c2434b97b80c7f8fdfaa072ca4baab7e239a15d6d70ed73a",
-                "sha256:7be0eec337359c155df191d6ae00a5e8bbb63933883f4f5dffc439dac5348c3f",
-                "sha256:94ae132f0e40fe48f310bba63f477f14a43116f05ddb69d6fa31e93f05848ae2",
-                "sha256:bb5829d027ff82aa872d76158919045a7c1e91fbf241aec32cb07956e9ebd3c9",
-                "sha256:ca238ceb7ba0bdf6ce88c1b74a87bffcee5afbfa1e41e173b1ceb095b39add46",
-                "sha256:ca28641954f767f9822c24e927ad894d45d5a1e501767599647259cbf030b903",
-                "sha256:e0344c14c9cb89e76eb6a060e67980c9e35b3f36691e15e1b7a9e58a0a6c6dc3",
-                "sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1",
-                "sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee"
+                "sha256:0a3bf09bb0b7a2c93ce7b98cb107e9170a90c51a0162a20af1c61c765b90e60b",
+                "sha256:1f64a62b3b75e4005df19d3b5235abd43fa6358d5516cfc43d87aeba8d08dd51",
+                "sha256:32db5cc49c73f39aac27574522cecd0a4bb7384e71198bc65a0d23f901e89bb7",
+                "sha256:4881d09298cd0b669bb15b9cfe6166f16fc1277b4ed0d04a22f3d6430cb30f1d",
+                "sha256:4e2dddd38a5ba733be6a025a1475a9f45e4e41139d1321f412c6b360b19070b6",
+                "sha256:53e0285b49fd0ab6e604f4c5d9c5ddd98de77018542e88366923f152dbeb3c29",
+                "sha256:70f8f4f7bb2ac9f340655cbac89d68c527af5bb4387522a8413e841e3e6628c9",
+                "sha256:7b2d54e787a884ffc6e187262823b6feb06c338084bbe80d45166a1cb1c6c5bf",
+                "sha256:7be666cc4599b415f320839e36367b273db8501127b38316f3b9f22f17a0b815",
+                "sha256:8241cac0aae90b82d6b5c443b853723bcc66963970c67e56e71a2609dc4b5eaf",
+                "sha256:82740818f2f240a5da8dfb8943b360e4f24022b093207160c77cadade47d7c85",
+                "sha256:8897b7b7ec077c819187a123174b645eb680c13df68354ed99f9b40a50898f77",
+                "sha256:c2c5250ff0d36fd58550252f54915776940e4e866f38f3a7866d92b32a654b86",
+                "sha256:ca9f686517ec2c4a4ce930207f75c00bf03d94e5063cbc00a1dc42531511b7eb",
+                "sha256:d2b3d199647468d410994dbeb8cec5816fb74feb9368aedf300af709ef507e3e",
+                "sha256:da73d095f8590ad437cd5e9faf6628a218aa7c387e1fdf67b888b47ba56a17f0",
+                "sha256:e167b6b710c7f7bc54e67ef593f8731e1f45aa35f8a8a7b72d6e42ec76afd4b3",
+                "sha256:ea634401ca02367c1567f012317502ef3437522e2fc44a3ea1844de028fa4b84",
+                "sha256:ec6597aa85ce03f3e507566b8bcdf9da2227ec86c4266bd5e6ab4d9e0cc8dab2",
+                "sha256:f64b232348ee82f13aac22856515ce0195837f6968aeaa94a3d0353ea2ec06a6"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==36.0.1"
+            "version": "==36.0.2"
         },
         "cssselect2": {
             "hashes": [
@@ -401,11 +416,11 @@
         },
         "dnspython": {
             "hashes": [
-                "sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44",
-                "sha256:e79351e032d0b606b98d38a4b0e6e2275b31a5b85c873e587cc11b73aca026d6"
+                "sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e",
+                "sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f"
             ],
             "markers": "python_version >= '3.6' and python_full_version < '4.0.0'",
-            "version": "==2.2.0"
+            "version": "==2.2.1"
         },
         "dojson": {
             "hashes": [
@@ -413,18 +428,6 @@
                 "sha256:fb5c362cea79ee1215778cdf36f0d2cca9885e1068fc90d6a6dafcc0ce8a7c5f"
             ],
             "version": "==1.4.0"
-        },
-        "dulwich": {
-            "hashes": [
-                "sha256:10699277c6268d0c16febe141a5b1c1a6e9744f3144c2d2de1706f4b1adafe63",
-                "sha256:267160904e9a1cb6c248c5efc53597a35d038ecc6f60bdc4546b3053bed11982",
-                "sha256:4e3aba5e4844e7c700721c1fc696987ea820ee3528a03604dc4e74eff4196826",
-                "sha256:60bb2c2c92f5025c1b53a556304008f0f624c98ae36f22d870e056b2d4236c11",
-                "sha256:dddae02d372fc3b5cfb0046d0f62246ef281fa0c088df7601ab5916607add94b",
-                "sha256:f00d132082b8fcc2eb0d722abc773d4aeb5558c1475d7edd1f0f571146c29db9",
-                "sha256:f74561c448bfb6f04c07de731c1181ae4280017f759b0bb04fa5770aa84ca850"
-            ],
-            "version": "==0.19.16"
         },
         "edtf": {
             "hashes": [
@@ -472,19 +475,19 @@
         },
         "faker": {
             "hashes": [
-                "sha256:206050b40d6dfb6efe8ccfbbb9866c56477c53edfdab83f80de3b59f38a88ce0",
-                "sha256:edb62f9511a0977abcea6a78e43b99d1f26c915d2142bbf4c6bf02a9bb597c7f"
+                "sha256:66db859b6abe376d02e805ad81eb8dcfce38f0945f17ee7cdf74ed349985ea52",
+                "sha256:fe969607836ce7100e38b88dcb598aacb733d895e6e9401894dd603e35623000"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==13.2.0"
+            "version": "==13.3.2"
         },
         "flask": {
             "hashes": [
-                "sha256:0fbeb6180d383a9186d0d6ed954e0042ad9f18e0e8de088b2b419d526927d196",
-                "sha256:c34f04500f2cbbea882b1acb02002ad6fe6b7ffa64a6164577995657f50aed22"
+                "sha256:59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f",
+                "sha256:e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.1.4"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.3"
         },
         "flask-admin": {
             "hashes": [
@@ -524,10 +527,11 @@
         },
         "flask-celeryext": {
             "hashes": [
-                "sha256:1c84b35462d41d1317800d256b2ce30031b7d3d20dd8dc680ce4f4cc88029867",
-                "sha256:47d5d18daebad300b215faca0d1c6da24625f333020482e27591634c05792c98"
+                "sha256:8f37c5b7afdbc3f4135c41d4b3dac3498faf4dbd681b19ffd91bc2f0a63d1d2b",
+                "sha256:aaa95aa4a2e5686a8eca2b53e5bbdff454613990574bcd98892e9a908d5adee6"
             ],
-            "version": "==0.3.4"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.4.1"
         },
         "flask-collect-invenio": {
             "hashes": [
@@ -598,10 +602,10 @@
         },
         "flask-resources": {
             "hashes": [
-                "sha256:0d4a85f2e9a02220c485604bacebdab836891162dfc417e96d4fb6d5369b3591",
-                "sha256:89e1744de549229b44517a0b7064a799035cb3933cb4330e731c7723aebc4926"
+                "sha256:50a2128ec3cc9aadad707edb55c8bb2ad218233a4bf3d4287635d90891a9fda1",
+                "sha256:78a8c59a1ec7ee5ed62964349032a67d5935c6b1dc8c7394f1afcba634a524f5"
             ],
-            "version": "==0.7.3"
+            "version": "==0.8.1"
         },
         "flask-restful": {
             "hashes": [
@@ -671,7 +675,7 @@
             "hashes": [
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.18.2"
         },
         "geojson": {
@@ -699,18 +703,18 @@
         },
         "idutils": {
             "hashes": [
-                "sha256:23ac47a026b0c709ffc79efd9fb54e4102913fb1f29a5bae56cd8f8f6cae124a",
-                "sha256:e9fb8eb0ce933d09fa347e01dc47ff28006b77bea434f4beb8d78bc693b2d01d"
+                "sha256:6246205d35d07466c9ce807a2bdf616eaacb3b8fc2934ccdf1bf51ea41785de7",
+                "sha256:c625193d7991f5c396aaf4c6af83865fb032ce51e1f60e7271d129d8df2bd2b1"
             ],
-            "version": "==1.1.11"
+            "version": "==1.1.12"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac",
-                "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"
+                "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6",
+                "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.11.2"
+            "version": "==4.11.3"
         },
         "importlib-resources": {
             "hashes": [
@@ -741,10 +745,10 @@
                 "metadata"
             ],
             "hashes": [
-                "sha256:1f46ddad695275e47f569301c0d625f889330b6826d7ad0628cff6a5ea60b283",
-                "sha256:7e2ebff88a0656accd92d48469b7638e813b9f3781b7c3414ad9b261a286c08f"
+                "sha256:cc28107035e917d085f4d576cb9a96cabe6d40ce8c40672dc420b2d5e2aa26ac",
+                "sha256:f366504531e9d481748193282a0183c10ed676911a661e125b4b627f1b1d8015"
             ],
-            "version": "==3.5.0a3"
+            "version": "==3.5.0a4"
         },
         "invenio-access": {
             "hashes": [
@@ -762,10 +766,10 @@
         },
         "invenio-admin": {
             "hashes": [
-                "sha256:dec80c123196390f7b78bec1c7f25f570e848382964504778b6f139b7612bab1",
-                "sha256:f7fd5821a9a705cf44ff9e15a910c13da4785e212be7d98d5bd1e444a1efd885"
+                "sha256:59148b6c2dd2583531c0b181314a7dfa3c7a48f9928966506641fd803bdc4df8",
+                "sha256:d4bd634d7c12d567429fdba9eecdf6202e9a8da7abfee3da311aee43ec9f0f2c"
             ],
-            "version": "==1.3.1"
+            "version": "==1.3.2"
         },
         "invenio-app": {
             "hashes": [
@@ -780,11 +784,11 @@
                 "postgresql"
             ],
             "hashes": [
-                "sha256:b55b07f313794e9b1f4c2e861316e5a9a81ec1c2381a357cce12f7177fe017e3",
-                "sha256:d04db3e7489119187c626484362cf11981fedab04a73033c0bbcbbaad9c1ab49"
+                "sha256:07d6748fcf927087af61f30029a7d5ebaa447abab52a7d862b9756f2e69bad06",
+                "sha256:e3bf97e6e4d500f0d97d74ed89971f7b58f9c961cd9257cafcc29b2e063347e9"
             ],
             "index": "pypi",
-            "version": "==6.0.5"
+            "version": "==8.0.0"
         },
         "invenio-assets": {
             "hashes": [
@@ -817,10 +821,10 @@
         },
         "invenio-communities": {
             "hashes": [
-                "sha256:0529ba600c269542549f61fec55c3b9968729d44b002d0200fdb5528ab925744",
-                "sha256:f8793778d0e1024d725ecf992385bafc893e98f20e580621214e1643607f118b"
+                "sha256:2a269c09f5f4346b0fa9350ff02bd6445c7d4976fb617cd2118bab7dc6157712",
+                "sha256:7d64916b557ee108a0c7a7674fe8205b68a270bbf801ea7084accd84d64519f4"
             ],
-            "version": "==2.5.0.dev2"
+            "version": "==2.7.0.dev9"
         },
         "invenio-config": {
             "hashes": [
@@ -842,10 +846,10 @@
         },
         "invenio-drafts-resources": {
             "hashes": [
-                "sha256:52465f049294a9f56ecaa9d975d221d5c65e469b71f1f7ca6a26332326bcfbfa",
-                "sha256:705d7e49da0c297f989137e79f25cc6dbf8e52fa5165d27ba9a5f3e1b1f4674e"
+                "sha256:19f3098fa9254b15e96db13d2918894d4c7094bd77403dcf3a7a87b1ea57ad3b",
+                "sha256:eb7b0589be513aba2e80647f4f3b6cc41a883fc55a289cd91df2911af48f7d77"
             ],
-            "version": "==0.13.7"
+            "version": "==0.15.5"
         },
         "invenio-files-rest": {
             "hashes": [
@@ -884,17 +888,20 @@
         },
         "invenio-jsonschemas": {
             "hashes": [
-                "sha256:566249180cc2ccec93eb941b0121aa0159a2abfde3ead0b8dd72391afbd9ab9a",
-                "sha256:cadfe98f6eef040bda2701c383c67afd5044078f138064f03b401a9b8704a222"
+                "sha256:95b37b1edb38b3eb10a3ef6fe280bc628a88b7b905efb5d0b57990dca2c1be19",
+                "sha256:99e406e1032812cabbd6c033645eb16739b275b91e8108061a4e98a896572d26"
             ],
-            "version": "==1.1.3"
+            "version": "==1.1.4"
         },
         "invenio-logging": {
-            "hashes": [
-                "sha256:0e0bc419d0f6296cde3bfa3c035bcfcd23ac80c4e8db3e748a91f81816092358",
-                "sha256:5910ed72bdec214ef14b254a9542017d60f0756838511c39a0c504c9e3a5d564"
+            "extras": [
+                "sentry-sdk"
             ],
-            "version": "==1.3.1"
+            "hashes": [
+                "sha256:353c4aba5ddb334ee45b801a2bc0b22e73e363163a776f0b3360d850dc3013ff",
+                "sha256:8c01c4dcc5604b996d30bf69dc35948536639943f5cb3d0da5240105ea08b533"
+            ],
+            "version": "==1.3.2"
         },
         "invenio-mail": {
             "hashes": [
@@ -905,17 +912,17 @@
         },
         "invenio-oaiserver": {
             "hashes": [
-                "sha256:6845d412a31c99275b9151581c0102914b7ad94d6f9a55807476e393b00be6db",
-                "sha256:cd35cae954a2f499c67935b2cfcc7061dbfc8b69f756f79ac649d92784a5e551"
+                "sha256:b4917291379b61022ad8b87afb9fe0d03574747a0fc48cedae7ef0e0377ecb37",
+                "sha256:ccd5cc57f8f9d3722d6b0935377eb5b63ee6c30e46f0c5e064b5cf9240d3159c"
             ],
-            "version": "==1.3.0"
+            "version": "==1.4.1"
         },
         "invenio-oauth2server": {
             "hashes": [
-                "sha256:98fcebc98180746533968a6e4fe3ec72568eb442cde904d11d07067825b52759",
-                "sha256:a460bb66a0a41520761488142dd0ddd7f3760fd84d6d16be4f8847b9d0926643"
+                "sha256:99c4af3bab3b30d855e1ec7b0a791aea5b6347d1c71afd0c8a80ae58d177ab9d",
+                "sha256:9c456a0ba4805ea95e7b8b2ac01060af95a7af97429e464288771eeeba2820ef"
             ],
-            "version": "==1.3.4"
+            "version": "==1.3.5"
         },
         "invenio-oauthclient": {
             "hashes": [
@@ -926,24 +933,24 @@
         },
         "invenio-pidstore": {
             "hashes": [
-                "sha256:625c313da90fb9a322b0cf0e331fb8b7bd121f6f96694905a64227f4d3aac917",
-                "sha256:960fd76702ebe159392e254ae9222503452383fa1ef0b94673ed0305552917f2"
+                "sha256:1ba4fb25d32a0aa23bd73ff611baea3f6bd055301b2cd55542ba526456cf3d7c",
+                "sha256:a879bcfc18d9623a0dcedd1110e407ffcea1a83298a6860aae598d0eb9e12b4f"
             ],
-            "version": "==1.2.2"
+            "version": "==1.2.3"
         },
         "invenio-previewer": {
             "hashes": [
-                "sha256:7a28c3f53d0b2ecd094f3e5d12fd2559e6d1adcc03cac6ca087ff35372aa49eb",
-                "sha256:8c6cd4e4f8b5ca22b4c57eb753fbca5c67dd2f02c54790c0b066e3a784449765"
+                "sha256:3907cc954c1b4cd321ff87c5d471e5dbc74d8d2fb1a48662638b630159867b4e",
+                "sha256:961016c4a584178ec22c4dffbbe17f36806c96ed4e6bcb4fec3eebf3125c9520"
             ],
-            "version": "==1.3.4"
+            "version": "==1.3.5"
         },
         "invenio-rdm-records": {
             "hashes": [
-                "sha256:8e12a37be04edbf1c955ee5974fefae05ef3f6776d424a8b23d101f0280d6f1d",
-                "sha256:d647969df443cef0c854214becef21b7d21d2f091e063c231190864ba7f98934"
+                "sha256:697fe237b3ff1db1237f0738e195d93596f9a7fcc62ce70038feb17ec012871e",
+                "sha256:a25bc309d9f72adc10698347a4f2bf7240a0a821b4f9d8620d6b934b96f54233"
             ],
-            "version": "==0.32.6"
+            "version": "==0.34.7"
         },
         "invenio-records": {
             "hashes": [
@@ -961,24 +968,24 @@
         },
         "invenio-records-permissions": {
             "hashes": [
-                "sha256:8926522cacf7777298adfddf9e701cac3c18d448ba5bdfca7bd6a6495de6aa3e",
-                "sha256:ac14c264b663db58ab9f8069bc81d3f19e3f65861b4614afa98211386dc4dc6c"
+                "sha256:381a37b4c6d7f9900fbdc59f81370b0b566a91c5bcf8bacf763abe088c353437",
+                "sha256:f061be7633f80fac626a5da1f8116b01dfff5146105e7faf12fda9f8241e84bd"
             ],
-            "version": "==0.12.1"
+            "version": "==0.13.0"
         },
         "invenio-records-resources": {
             "hashes": [
-                "sha256:389ad78177e09af6c8283c5a24312bf79b33905801dfede18f49e99ba4133d5d",
-                "sha256:cdd94b553ca9c459a912dc6c4665c8026f9e5810382b84460f93464913b0865e"
+                "sha256:44c590dd09748deffa62cd6714557d25fb6f755c7863f7c1bd53c3f436d5f74f",
+                "sha256:5da81baea44aa4f0d45f41265466adb3d3852af064fe944c27e6a76d2610510e"
             ],
-            "version": "==0.16.14"
+            "version": "==0.18.5"
         },
         "invenio-records-rest": {
             "hashes": [
-                "sha256:67fb753131e00bd20aef9d1011d51bcb407d1a30ef2e4af8647bf3b92f2b999e",
-                "sha256:70ba741f19f8c9a1ae14a700d82c632175e881fd786ffdc4692f2718482e8dd1"
+                "sha256:6e60f45478e3131640b6a385a18d78bb8decf030f421f25382ace5766091b52f",
+                "sha256:bcb93941fb1ac1ccb85189d6a8db43d8134bfa985f711a36c1bae7823764da4f"
             ],
-            "version": "==1.8.0"
+            "version": "==1.9.0"
         },
         "invenio-records-ui": {
             "hashes": [
@@ -986,6 +993,14 @@
                 "sha256:d465ed33645712f4c6144836ffca80f3773e7aec3ef596a9f95bafc14535335b"
             ],
             "version": "==1.2.0"
+        },
+        "invenio-requests": {
+            "hashes": [
+                "sha256:b3f4bcdc1b7a3b7085fd5cbef68b26587f839c4702369116e6862ad680b02555",
+                "sha256:d77256cb719c2258b008a864380bc06a8c15bc0a9cfe8ea3887b6280e37ac6a4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.2.12"
         },
         "invenio-rest": {
             "extras": [
@@ -1009,17 +1024,17 @@
         },
         "invenio-search-ui": {
             "hashes": [
-                "sha256:6bf925c9136bf34d627c64b8029c29e62569572c92dc2fa626bb8b6ef5a56b44",
-                "sha256:c5171a5019f2d7fb39cb21ae79381d3bdb50222b0df128c499a92af6388b6afe"
+                "sha256:1fecb5d1ab10449757f278b7ec6e46c3c8c55d522121ff1576b19758e87322f0",
+                "sha256:bc6661a7a625126a3094abe0fc3376ae778f6f7456ee597fa6040aa9a0aacf97"
             ],
-            "version": "==2.0.5"
+            "version": "==2.0.7"
         },
         "invenio-theme": {
             "hashes": [
-                "sha256:207606bea70e6f897c7e95ddfb81c8c4ff7e2ed73334d5e91efbd747567d30c6",
-                "sha256:e90c1f6d58bda5441daa1c5f999264dda403da19228ed25069fe8ed2e1e34efb"
+                "sha256:a5a0b09f48b11a224022aa84b1dc8a66a936320bb68d8461512f2e09237ef15d",
+                "sha256:b3895108905b2ded88fb07c4b5b8ceb690cb3b33428f192b8d1ee38e4101f82d"
             ],
-            "version": "==1.3.16"
+            "version": "==1.3.20"
         },
         "invenio-userprofiles": {
             "hashes": [
@@ -1030,10 +1045,10 @@
         },
         "invenio-vocabularies": {
             "hashes": [
-                "sha256:69c69311fc34dd41a2739658e33bf52fe8f26c9a5ea4b367228dde050c9fc0b5",
-                "sha256:e3e1b8df0c44975301bd1d6b1743e8f5caf4aeca28d91eebf242544629b02bf2"
+                "sha256:25d6d28804a67292493e8a78123870423317fb5f11b21d24ee84f16ff6dc50cd",
+                "sha256:50bb97a876bdd6e2617ed5cdc157ebb91b772923f5f767051b7ca5744d97b5d4"
             ],
-            "version": "==0.8.1"
+            "version": "==0.10.5"
         },
         "ipython": {
             "hashes": [
@@ -1043,26 +1058,20 @@
             "index": "pypi",
             "version": "==8.0.1"
         },
-        "ipython-genutils": {
+        "isbnlib": {
             "hashes": [
-                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
-                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+                "sha256:623a09329e8ec7049edf15dd412db042bf4f8236a428bf7a22d84a125584f52d",
+                "sha256:c9e6c1dcaa9dff195429373cf2beb3117f30b3fca43d7db5aec5a2d1f6f59784"
             ],
-            "version": "==0.2.0"
-        },
-        "isbnid-fork": {
-            "hashes": [
-                "sha256:8d878866aa0e7f06e700a37fce586c7398ce4837da8bca39683db7028a9c3837"
-            ],
-            "version": "==0.5.2"
+            "version": "==3.10.10"
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
-                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
+                "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
+                "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.1.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
         },
         "jedi": {
             "hashes": [
@@ -1074,11 +1083,11 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
-                "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
+                "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8",
+                "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.11.3"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.3"
         },
         "jsmin": {
             "hashes": [
@@ -1141,11 +1150,11 @@
         },
         "kombu": {
             "hashes": [
-                "sha256:81a90c1de97e08d3db37dbf163eaaf667445e1068c98bfd89f051a40e9f6dbbd",
-                "sha256:eeaeb8024f3a5cfc71c9250e45cddb8493f269d74ada2f74909a93c59c4b4179"
+                "sha256:37cee3ee725f94ea8bb173eaab7c1760203ea53bbebae226328600f9d2799610",
+                "sha256:8b213b24293d3417bcf0d2f5537b7f756079e3ea232a8386dcc89a59fd2361a4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.2.3"
+            "version": "==5.2.4"
         },
         "limits": {
             "hashes": [
@@ -1230,11 +1239,11 @@
         },
         "mako": {
             "hashes": [
-                "sha256:4e9e345a41924a954251b95b4b28e14a301145b544901332e658907a7464b6b2",
-                "sha256:afaf8e515d075b22fad7d7b8b30e4a1c90624ff2f3733a06ec125f5a5f043a57"
+                "sha256:23aab11fdbbb0f1051b93793a58323ff937e98e34aece1c4219675122e57e4ba",
+                "sha256:9a7c7e922b87db3686210cf49d5d767033a41d4010b284e747682c92bddd8b39"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.1.6"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.0"
         },
         "markupsafe": {
             "hashes": [
@@ -1313,11 +1322,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:04438610bc6dadbdddb22a4a55bcc7f6f8099e69580b2e67f5a681933a1f4400",
-                "sha256:4c05c1684e0e97fe779c62b91878f173b937fe097b356cd82f793464f5bc6138"
+                "sha256:2aaaab4f01ef4f5a011a21319af9fce17ab13bf28a026d1252adab0e035648d5",
+                "sha256:ff79885ed43b579782f48c251d262e062bce49c65c52412458769a4fb57ac30f"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.14.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.15.0"
         },
         "marshmallow-oneofschema": {
             "hashes": [
@@ -1329,10 +1338,10 @@
         },
         "marshmallow-utils": {
             "hashes": [
-                "sha256:25d4c9b063b62107a643d21205f7f00bec07bb6ef683225ae8e5cc8b44a22a43",
-                "sha256:7bf53458d554bcdcd8d21e2dd429a5913039c7256873723c1c6fdb48e57a5214"
+                "sha256:3c24569fd3cd9cb7d89400bef09d2ec3c4012067f07b4bdda4129b07a3c4add0",
+                "sha256:7d3aa62463882e4e8dc19ad8a68dc450f3f90405073bb75bf87b6f03be48504f"
             ],
-            "version": "==0.5.4"
+            "version": "==0.5.5"
         },
         "matplotlib-inline": {
             "hashes": [
@@ -1421,11 +1430,11 @@
         },
         "nbformat": {
             "hashes": [
-                "sha256:b516788ad70771c6250977c1374fcca6edebe6126fd2adb5a69aa5c2356fd1c8",
-                "sha256:eb8447edd7127d043361bc17f2f5a807626bc8e878c7709a1c647abda28a9171"
+                "sha256:3e30424e8291b2188347f5c3ba5273ed3766f12f8c5137c2e456a0815f36e785",
+                "sha256:93df0b9c67221d38fb970c48f6d361819a6c388299a0ef3171bbb912edfe1324"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==5.1.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==5.2.0"
         },
         "nest-asyncio": {
             "hashes": [
@@ -1650,10 +1659,10 @@
         },
         "pycountry": {
             "hashes": [
-                "sha256:b9a6d9cdbf53f81ccdf73f6f5de01b0d8493cab2213a230af3e34458de85ea32"
+                "sha256:b2163a246c585894d808f18783e19137cb70a0c18fb36748dc01fc6f109c1646"
             ],
-            "markers": "python_version >= '3.5' and python_full_version < '4.0.0'",
-            "version": "==22.1.10"
+            "markers": "python_version >= '3.6' and python_full_version < '4.0.0'",
+            "version": "==22.3.5"
         },
         "pycparser": {
             "hashes": [
@@ -1725,7 +1734,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pytz": {
@@ -1783,64 +1792,68 @@
         },
         "pyzmq": {
             "hashes": [
-                "sha256:08c4e315a76ef26eb833511ebf3fa87d182152adf43dedee8d79f998a2162a0b",
-                "sha256:0ca6cd58f62a2751728016d40082008d3b3412a7f28ddfb4a2f0d3c130f69e74",
-                "sha256:1621e7a2af72cced1f6ec8ca8ca91d0f76ac236ab2e8828ac8fe909512d566cb",
-                "sha256:18cd854b423fce44951c3a4d3e686bac8f1243d954f579e120a1714096637cc0",
-                "sha256:2841997a0d85b998cbafecb4183caf51fd19c4357075dfd33eb7efea57e4c149",
-                "sha256:2b97502c16a5ec611cd52410bdfaab264997c627a46b0f98d3f666227fd1ea2d",
-                "sha256:3a4c9886d61d386b2b493377d980f502186cd71d501fffdba52bd2a0880cef4f",
-                "sha256:3c1895c95be92600233e476fe283f042e71cf8f0b938aabf21b7aafa62a8dac9",
-                "sha256:42abddebe2c6a35180ca549fadc7228d23c1e1f76167c5ebc8a936b5804ea2df",
-                "sha256:468bd59a588e276961a918a3060948ae68f6ff5a7fa10bb2f9160c18fe341067",
-                "sha256:480b9931bfb08bf8b094edd4836271d4d6b44150da051547d8c7113bf947a8b0",
-                "sha256:53f4fd13976789ffafedd4d46f954c7bb01146121812b72b4ddca286034df966",
-                "sha256:62bcade20813796c426409a3e7423862d50ff0639f5a2a95be4b85b09a618666",
-                "sha256:67db33bea0a29d03e6eeec55a8190e033318cee3cbc732ba8fd939617cbf762d",
-                "sha256:6b217b8f9dfb6628f74b94bdaf9f7408708cb02167d644edca33f38746ca12dd",
-                "sha256:7661fc1d5cb73481cf710a1418a4e1e301ed7d5d924f91c67ba84b2a1b89defd",
-                "sha256:76c532fd68b93998aab92356be280deec5de8f8fe59cd28763d2cc8a58747b7f",
-                "sha256:79244b9e97948eaf38695f4b8e6fc63b14b78cc37f403c6642ba555517ac1268",
-                "sha256:7c58f598d9fcc52772b89a92d72bf8829c12d09746a6d2c724c5b30076c1f11d",
-                "sha256:7dc09198e4073e6015d9a8ea093fc348d4e59de49382476940c3dd9ae156fba8",
-                "sha256:80e043a89c6cadefd3a0712f8a1322038e819ebe9dbac7eca3bce1721bcb63bf",
-                "sha256:851977788b9caa8ed011f5f643d3ee8653af02c5fc723fa350db5125abf2be7b",
-                "sha256:8eddc033e716f8c91c6a2112f0a8ebc5e00532b4a6ae1eb0ccc48e027f9c671c",
-                "sha256:902319cfe23366595d3fa769b5b751e6ee6750a0a64c5d9f757d624b2ac3519e",
-                "sha256:954e73c9cd4d6ae319f1c936ad159072b6d356a92dcbbabfd6e6204b9a79d356",
-                "sha256:ab888624ed68930442a3f3b0b921ad7439c51ba122dbc8c386e6487a658e4a4e",
-                "sha256:acebba1a23fb9d72b42471c3771b6f2f18dcd46df77482612054bd45c07dfa36",
-                "sha256:b4ebed0977f92320f6686c96e9e8dd29eed199eb8d066936bac991afc37cbb70",
-                "sha256:badb868fff14cfd0e200eaa845887b1011146a7d26d579aaa7f966c203736b92",
-                "sha256:be4e0f229cf3a71f9ecd633566bd6f80d9fa6afaaff5489492be63fe459ef98c",
-                "sha256:c0f84360dcca3481e8674393bdf931f9f10470988f87311b19d23cda869bb6b7",
-                "sha256:c1e41b32d6f7f9c26bc731a8b529ff592f31fc8b6ef2be9fa74abd05c8a342d7",
-                "sha256:c88fa7410e9fc471e0858638f403739ee869924dd8e4ae26748496466e27ac59",
-                "sha256:cf98fd7a6c8aaa08dbc699ffae33fd71175696d78028281bc7b832b26f00ca57",
-                "sha256:d072f7dfbdb184f0786d63bda26e8a0882041b1e393fbe98940395f7fab4c5e2",
-                "sha256:d1b5d457acbadcf8b27561deeaa386b0217f47626b29672fa7bd31deb6e91e1b",
-                "sha256:d3dcb5548ead4f1123851a5ced467791f6986d68c656bc63bfff1bf9e36671e2",
-                "sha256:d6157793719de168b199194f6b6173f0ccd3bf3499e6870fac17086072e39115",
-                "sha256:d728b08448e5ac3e4d886b165385a262883c34b84a7fe1166277fe675e1c197a",
-                "sha256:de8df0684398bd74ad160afdc2a118ca28384ac6f5e234eb0508858d8d2d9364",
-                "sha256:e6a02cf7271ee94674a44f4e62aa061d2d049001c844657740e156596298b70b",
-                "sha256:ea12133df25e3a6918718fbb9a510c6ee5d3fdd5a346320421aac3882f4feeea",
-                "sha256:ea5a79e808baef98c48c884effce05c31a0698c1057de8fc1c688891043c1ce1",
-                "sha256:f43b4a2e6218371dd4f41e547bd919ceeb6ebf4abf31a7a0669cd11cd91ea973",
-                "sha256:f762442bab706fd874064ca218b33a1d8e40d4938e96c24dafd9b12e28017f45",
-                "sha256:f89468059ebc519a7acde1ee50b779019535db8dcf9b8c162ef669257fef7a93",
-                "sha256:f907c7359ce8bf7f7e63c82f75ad0223384105f5126f313400b7e8004d9b33c3"
+                "sha256:031417b5d450baf645cf9dbf6d156399010505867f0e0db7ce32e50b83c4f4c8",
+                "sha256:07b4f6f852ded85db1e1939fd9c08cb8b548ad07a386f7237cdebe1b884dffac",
+                "sha256:099b59e2bdf7bb08599b21425f82e896682642293fe7eddeb0afbe2c79bfa97a",
+                "sha256:113df7f444c7e60a09f940edc4366d1ba33f374527f9a57096b0eeda731430b9",
+                "sha256:21529e58514c42598f1ad8ca5551b09e52533e8c13a93d0588b10e9f38b1c045",
+                "sha256:22581b4b5becf830ab42b36412100eceb412b1dd3367627e67dd4ed8754f5055",
+                "sha256:226c6a705f33303752bcc7c6979c1cc0db4178c4e7011b8a53398200d49e6c47",
+                "sha256:232b1511bc81ae0a44002f3b7f42e96813353c2a19b1eeedcb36a0867755606d",
+                "sha256:2aaa587eb77fce70a5f85fba8711f70a6e8a0c84e5aa75d28f1c47acbbdc3b80",
+                "sha256:37cfba29611afde16e6f3cc24e6a5c2ef802923f40df4f5ef4cda53dc9ac774a",
+                "sha256:3b93edc90e6dcca5cdb21a67a92cc593c06b9bc681ffef1665e84c6cc8fc14ff",
+                "sha256:49300eb7c25046e54459f2e3815a1db430e44f309a28bf70b0c8aedf8c5370a9",
+                "sha256:4bd5ecf70fd80c0f3debb585412fecace3fecab59665a30437cf9424df5514fe",
+                "sha256:4dca17b0b27603b2c202b694f440c4b60d1c9c1a4966df9d361cd98b7f41270f",
+                "sha256:50184458e22ca6e7c18364dc825a177d607a08d8d9bd2bc5577b16169c1f85cd",
+                "sha256:51e3b39364e069264e451c710b74d46cb1484bc88a17f8ff7c8f8ea2d97c7181",
+                "sha256:52b1b41488988f0f60c347166e659e9ff530b8f8395896394e177b842ea8835d",
+                "sha256:532dd70586511bd000671a17b59124d9d599164fc76512ab798fa334522f774c",
+                "sha256:5ca84bb9f649ee06192ee0a7120b398cc447eaac187e9bc689e9e8ba843fde99",
+                "sha256:5e4121b525d90330524b6ee7aa8a8c83bf2c1e01709963611d857ebc14f80a3e",
+                "sha256:656d2a54411c1f204f579c88480641d0a9503eb7eb98517f90ace4cf2897af99",
+                "sha256:664b7f57330470a8354f248650958c91d1d806408e13fece3d38b545f43e6e3e",
+                "sha256:6d9025bca175aaecc0f54b2895bef22dc154ca13824a0828f6be4efcdaadefed",
+                "sha256:7280ecd232e439e040b5cd5ebdd5d5ebaa46cbcd1163e1fd0be236f9871047be",
+                "sha256:7a5ac470da6bb13f022c5e392d4528f05d5cadb37702ed434c652aa2ef5538c1",
+                "sha256:81ff0ec9c4d81db3b91d9568c3051ced6e81637ac912bc30d149cf54b1e3cee3",
+                "sha256:8306f064bf4603381313e4fa66d3b04c50ae8df6888c538d2c1d8072c4c36443",
+                "sha256:830fd69828931fcd67a283485dc0a9ad1a54c48514a0f68f0d559ab7de1cc7a2",
+                "sha256:83f8dfbb6711e956a6705e8dbdfc0df32f34bb2aad0f19128bc6abe2fbffe1b2",
+                "sha256:850032302a9bff470788813389482ad76f83448f2b448b2885ab479d370a9ac3",
+                "sha256:88786376e7a13dbe37181e6ca079ffdca55186fd80eb44b97ad4d6e5579d5294",
+                "sha256:8d4cf52e1a2ffe398315c026435dea8a3f09ba12deea88302b3fb5d3527264e1",
+                "sha256:98f869ff401a1f4c6104fecf44b21ad027b6a94240d565c67528eac96c6a7b4e",
+                "sha256:9a74e6080b3f76486fe26d35e84c3734081bab729f0124df0b27ae2612cee260",
+                "sha256:a17befeb4f532b3a80f4befa889b5e6a21c7113a5c145b4dd3a7bb472df0815f",
+                "sha256:a5cf28f9d566216470357b107147b9ec320025bdc40ca0f0d1d6603a958c3a60",
+                "sha256:b1495d9d520384c4ac30814943bc3a45d005aee2c9362c91ad536b1db5660ec1",
+                "sha256:b63605f2ee5c5bca4d762e876c8879760bf046510687de735e28103f072a2d77",
+                "sha256:bb612af9dc23d80688ace7f005a9ed4e5dae20c988dd197381e7e20d49836c11",
+                "sha256:c2e1071a11c1bf62888859c761e33a20840ac70819b5c86a55b4ebec3cf8733e",
+                "sha256:c887bc1a80bef14aa12f1756bd8e976c3f3a4d5fd410ba17454a382a00cfe721",
+                "sha256:d0a30aac29088a1e11777ce2221bb08f85a9fdb2b386d6fd02f9f36260b48338",
+                "sha256:d6cced1b564ca1da4ba9e19de88d9cc0422b75ffab869f1bb21ceccd754c6bf5",
+                "sha256:d8859098ff2bcf3fe2e43d3c6915127a45363a90534d1f2af9487ae87c2920db",
+                "sha256:e4a189b86adfd0075cc9e41550540cd620a17f74c118d2cf6af0361be07e1d82",
+                "sha256:e7da43aebe4dc18349f716470f728afbae449d4cfd3945ba6805a563e0ddc1be",
+                "sha256:f1fc63e7eef23418cdfe8169dbcb0964c36f7c180f60dae122c0f9bb359df2f7",
+                "sha256:f2c7bf98fdb2f81304921a9aa25ae73b5fdeae0da2fb46d1efec94ba8ffb34d6",
+                "sha256:f3bbcfde5466c2e3c63d0f77a12daf19308ffa9b03fe0758424bb61b8150abfd",
+                "sha256:fb9c3747c6516da0b21d4e38d4f433db0216f8e214173bd02a916d8deda68ef2",
+                "sha256:fd4bf5dfe291611881a19059bcd5b973475f46deaa4fc88fb4357013ed6c4b09"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==22.3.0"
+            "version": "==23.0.0b1"
         },
         "redis": {
             "hashes": [
-                "sha256:95ff6381bc15acbb330d24896601fb8c50468003c0f30c9503afda2907225d08",
-                "sha256:f5c52d3bb91d1ce94f0abaf7a660de7d95ea02cccd0cd0930912c49285fced6f"
+                "sha256:001d2b22a7c4e29497ba893fe30d6c6e7b59b088f206374841c328c7f34003ec",
+                "sha256:7a79121ae02f4dfb9d6179ece854536c018a376359bd93fdcc9c363b048c5907"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.2.0rc1"
+            "version": "==4.2.0rc3"
         },
         "requests": {
             "hashes": [
@@ -1858,13 +1871,23 @@
             ],
             "version": "==1.1.0"
         },
+        "sentry-sdk": {
+            "extras": [
+                "flask"
+            ],
+            "hashes": [
+                "sha256:411a8495bd18cf13038e5749e4710beb4efa53da6351f67b4c2f307c2d9b6d49",
+                "sha256:aa52da941c56b5a76fd838f8e9e92a850bf893a9eb1e33ffce6c21431d07ee30"
+            ],
+            "version": "==1.5.7"
+        },
         "setuptools": {
             "hashes": [
-                "sha256:2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5",
-                "sha256:e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b"
+                "sha256:22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373",
+                "sha256:4ce92f1e1f8f01233ee9952c04f6b81d1e02939d6e1b488428154974a4d0783e"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==60.9.3"
+            "markers": "python_version >= '3.6'",
+            "version": "==59.6.0"
         },
         "simplejson": {
             "hashes": [
@@ -1930,7 +1953,7 @@
                 "sha256:f63600ec06982cdf480899026f4fda622776f5fabed9a869fdb32d72bc17e99a",
                 "sha256:fb62d517a516128bacf08cb6a86ecd39fb06d08e7c4980251f5d5601d29989ba"
             ],
-            "markers": "python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.17.6"
         },
         "simplekv": {
@@ -1946,7 +1969,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "speaklater": {
@@ -2033,11 +2056,11 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f",
-                "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.2.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
         },
         "tornado": {
             "hashes": [
@@ -2093,11 +2116,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
-                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
+                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
-            "version": "==1.26.8"
+            "version": "==1.26.9"
         },
         "uwsgi": {
             "hashes": [
@@ -2168,68 +2191,81 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
-                "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
+                "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8",
+                "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.0.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.3"
         },
         "wrapt": {
             "hashes": [
-                "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179",
-                "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096",
-                "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374",
-                "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df",
-                "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185",
-                "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785",
-                "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7",
-                "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909",
-                "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918",
-                "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33",
-                "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068",
-                "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829",
-                "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af",
-                "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79",
-                "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce",
-                "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc",
-                "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36",
-                "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade",
-                "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca",
-                "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32",
-                "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125",
-                "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e",
-                "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709",
-                "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f",
-                "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b",
-                "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb",
-                "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb",
-                "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489",
-                "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640",
-                "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb",
-                "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851",
-                "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d",
-                "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44",
-                "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13",
-                "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2",
-                "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb",
-                "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b",
-                "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9",
-                "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755",
-                "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c",
-                "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a",
-                "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf",
-                "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3",
-                "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229",
-                "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e",
-                "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de",
-                "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554",
-                "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10",
-                "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80",
-                "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056",
-                "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"
+                "sha256:00108411e0f34c52ce16f81f1d308a571df7784932cc7491d1e94be2ee93374b",
+                "sha256:01f799def9b96a8ec1ef6b9c1bbaf2bbc859b87545efbecc4a78faea13d0e3a0",
+                "sha256:09d16ae7a13cff43660155383a2372b4aa09109c7127aa3f24c3cf99b891c330",
+                "sha256:14e7e2c5f5fca67e9a6d5f753d21f138398cad2b1159913ec9e9a67745f09ba3",
+                "sha256:167e4793dc987f77fd476862d32fa404d42b71f6a85d3b38cbce711dba5e6b68",
+                "sha256:1807054aa7b61ad8d8103b3b30c9764de2e9d0c0978e9d3fc337e4e74bf25faa",
+                "sha256:1f83e9c21cd5275991076b2ba1cd35418af3504667affb4745b48937e214bafe",
+                "sha256:21b1106bff6ece8cb203ef45b4f5778d7226c941c83aaaa1e1f0f4f32cc148cd",
+                "sha256:22626dca56fd7f55a0733e604f1027277eb0f4f3d95ff28f15d27ac25a45f71b",
+                "sha256:23f96134a3aa24cc50614920cc087e22f87439053d886e474638c68c8d15dc80",
+                "sha256:2498762814dd7dd2a1d0248eda2afbc3dd9c11537bc8200a4b21789b6df6cd38",
+                "sha256:28c659878f684365d53cf59dc9a1929ea2eecd7ac65da762be8b1ba193f7e84f",
+                "sha256:2eca15d6b947cfff51ed76b2d60fd172c6ecd418ddab1c5126032d27f74bc350",
+                "sha256:354d9fc6b1e44750e2a67b4b108841f5f5ea08853453ecbf44c81fdc2e0d50bd",
+                "sha256:36a76a7527df8583112b24adc01748cd51a2d14e905b337a6fefa8b96fc708fb",
+                "sha256:3a0a4ca02752ced5f37498827e49c414d694ad7cf451ee850e3ff160f2bee9d3",
+                "sha256:3a71dbd792cc7a3d772ef8cd08d3048593f13d6f40a11f3427c000cf0a5b36a0",
+                "sha256:3a88254881e8a8c4784ecc9cb2249ff757fd94b911d5df9a5984961b96113fff",
+                "sha256:47045ed35481e857918ae78b54891fac0c1d197f22c95778e66302668309336c",
+                "sha256:4775a574e9d84e0212f5b18886cace049a42e13e12009bb0491562a48bb2b758",
+                "sha256:493da1f8b1bb8a623c16552fb4a1e164c0200447eb83d3f68b44315ead3f9036",
+                "sha256:4b847029e2d5e11fd536c9ac3136ddc3f54bc9488a75ef7d040a3900406a91eb",
+                "sha256:59d7d92cee84a547d91267f0fea381c363121d70fe90b12cd88241bd9b0e1763",
+                "sha256:5a0898a640559dec00f3614ffb11d97a2666ee9a2a6bad1259c9facd01a1d4d9",
+                "sha256:5a9a1889cc01ed2ed5f34574c90745fab1dd06ec2eee663e8ebeefe363e8efd7",
+                "sha256:5b835b86bd5a1bdbe257d610eecab07bf685b1af2a7563093e0e69180c1d4af1",
+                "sha256:5f24ca7953f2643d59a9c87d6e272d8adddd4a53bb62b9208f36db408d7aafc7",
+                "sha256:61e1a064906ccba038aa3c4a5a82f6199749efbbb3cef0804ae5c37f550eded0",
+                "sha256:65bf3eb34721bf18b5a021a1ad7aa05947a1767d1aa272b725728014475ea7d5",
+                "sha256:6807bcee549a8cb2f38f73f469703a1d8d5d990815c3004f21ddb68a567385ce",
+                "sha256:68aeefac31c1f73949662ba8affaf9950b9938b712fb9d428fa2a07e40ee57f8",
+                "sha256:6915682f9a9bc4cf2908e83caf5895a685da1fbd20b6d485dafb8e218a338279",
+                "sha256:6d9810d4f697d58fd66039ab959e6d37e63ab377008ef1d63904df25956c7db0",
+                "sha256:729d5e96566f44fccac6c4447ec2332636b4fe273f03da128fff8d5559782b06",
+                "sha256:748df39ed634851350efa87690c2237a678ed794fe9ede3f0d79f071ee042561",
+                "sha256:763a73ab377390e2af26042f685a26787c402390f682443727b847e9496e4a2a",
+                "sha256:8323a43bd9c91f62bb7d4be74cc9ff10090e7ef820e27bfe8815c57e68261311",
+                "sha256:8529b07b49b2d89d6917cfa157d3ea1dfb4d319d51e23030664a827fe5fd2131",
+                "sha256:87fa943e8bbe40c8c1ba4086971a6fefbf75e9991217c55ed1bcb2f1985bd3d4",
+                "sha256:88236b90dda77f0394f878324cfbae05ae6fde8a84d548cfe73a75278d760291",
+                "sha256:891c353e95bb11abb548ca95c8b98050f3620a7378332eb90d6acdef35b401d4",
+                "sha256:89ba3d548ee1e6291a20f3c7380c92f71e358ce8b9e48161401e087e0bc740f8",
+                "sha256:8c6be72eac3c14baa473620e04f74186c5d8f45d80f8f2b4eda6e1d18af808e8",
+                "sha256:9a242871b3d8eecc56d350e5e03ea1854de47b17f040446da0e47dc3e0b9ad4d",
+                "sha256:9a3ff5fb015f6feb78340143584d9f8a0b91b6293d6b5cf4295b3e95d179b88c",
+                "sha256:9a5a544861b21e0e7575b6023adebe7a8c6321127bb1d238eb40d99803a0e8bd",
+                "sha256:9d57677238a0c5411c76097b8b93bdebb02eb845814c90f0b01727527a179e4d",
+                "sha256:9d8c68c4145041b4eeae96239802cfdfd9ef927754a5be3f50505f09f309d8c6",
+                "sha256:9d9fcd06c952efa4b6b95f3d788a819b7f33d11bea377be6b8980c95e7d10775",
+                "sha256:a0057b5435a65b933cbf5d859cd4956624df37b8bf0917c71756e4b3d9958b9e",
+                "sha256:a65bffd24409454b889af33b6c49d0d9bcd1a219b972fba975ac935f17bdf627",
+                "sha256:b0ed6ad6c9640671689c2dbe6244680fe8b897c08fd1fab2228429b66c518e5e",
+                "sha256:b21650fa6907e523869e0396c5bd591cc326e5c1dd594dcdccac089561cacfb8",
+                "sha256:b3f7e671fb19734c872566e57ce7fc235fa953d7c181bb4ef138e17d607dc8a1",
+                "sha256:b77159d9862374da213f741af0c361720200ab7ad21b9f12556e0eb95912cd48",
+                "sha256:bb36fbb48b22985d13a6b496ea5fb9bb2a076fea943831643836c9f6febbcfdc",
+                "sha256:d066ffc5ed0be00cd0352c95800a519cf9e4b5dd34a028d301bdc7177c72daf3",
+                "sha256:d332eecf307fca852d02b63f35a7872de32d5ba8b4ec32da82f45df986b39ff6",
+                "sha256:d808a5a5411982a09fef6b49aac62986274ab050e9d3e9817ad65b2791ed1425",
+                "sha256:d9bdfa74d369256e4218000a629978590fd7cb6cf6893251dad13d051090436d",
+                "sha256:db6a0ddc1282ceb9032e41853e659c9b638789be38e5b8ad7498caac00231c23",
+                "sha256:debaf04f813ada978d7d16c7dfa16f3c9c2ec9adf4656efdc4defdf841fc2f0c",
+                "sha256:f0408e2dbad9e82b4c960274214af533f856a199c9274bd4aff55d4634dedc33",
+                "sha256:f2f3bc7cd9c9fcd39143f11342eb5963317bd54ecc98e3650ca22704b69d9653"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.13.3"
+            "version": "==1.14.0"
         },
         "wtforms": {
             "hashes": [
@@ -2278,11 +2314,11 @@
         },
         "check-manifest": {
             "hashes": [
-                "sha256:365c94d65de4c927d9d8b505371d08ee19f9f369c86b9ac3db97c2754c827c95",
-                "sha256:56dadd260a9c7d550b159796d2894b6d0bcc176a94cbc426d9bb93e5e48d12ce"
+                "sha256:3b575f1dade7beb3078ef4bf33a94519834457c7281dbc726b15c5466b55c657",
+                "sha256:b1923685f98c1c2468601a1a7bed655db549a25d43c583caded3860ad8308f8c"
             ],
             "index": "pypi",
-            "version": "==0.47"
+            "version": "==0.48"
         },
         "packaging": {
             "hashes": [
@@ -2309,27 +2345,19 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5",
-                "sha256:e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b"
+                "sha256:22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373",
+                "sha256:4ce92f1e1f8f01233ee9952c04f6b81d1e02939d6e1b488428154974a4d0783e"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==60.9.3"
-        },
-        "toml": {
-            "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==0.10.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==59.6.0"
         },
         "tomli": {
             "hashes": [
-                "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f",
-                "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.2.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "85eec31deb47f15197539a5148497c8f1b90f0a1e89115cbdff414720f914c86"
+            "sha256": "f215e035629dd4f31f82694d2edff31726f6eae13a9a51bd433d7cc8b8d7c676"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -113,35 +113,6 @@
             ],
             "version": "==3.6.4.0"
         },
-        "black": {
-            "hashes": [
-                "sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2",
-                "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71",
-                "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6",
-                "sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5",
-                "sha256:2d6f331c02f0f40aa51a22e479c8209d37fcd520c77721c034517d44eecf5912",
-                "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866",
-                "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d",
-                "sha256:35944b7100af4a985abfcaa860b06af15590deb1f392f06c8683b4381e8eeaf0",
-                "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321",
-                "sha256:5fa1db02410b1924b6749c245ab38d30621564e658297484952f3d8a39fce7e8",
-                "sha256:6f2f01381f91c1efb1451998bd65a129b3ed6f64f79663a55fe0e9b74a5f81fd",
-                "sha256:742ce9af3086e5bd07e58c8feb09dbb2b047b7f566eb5f5bc63fd455814979f3",
-                "sha256:7835fee5238fc0a0baf6c9268fb816b5f5cd9b8793423a75e8cd663c48d073ba",
-                "sha256:8871fcb4b447206904932b54b567923e5be802b9b19b744fdff092bd2f3118d0",
-                "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5",
-                "sha256:b1a5ed73ab4c482208d20434f700d514f66ffe2840f63a6252ecc43a9bc77e8a",
-                "sha256:c8226f50b8c34a14608b848dc23a46e5d08397d009446353dad45e04af0c8e28",
-                "sha256:ccad888050f5393f0d6029deea2a33e5ae371fd182a697313bdbd835d3edaf9c",
-                "sha256:dae63f2dbf82882fa3b2a3c49c32bffe144970a573cd68d247af6560fc493ae1",
-                "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab",
-                "sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f",
-                "sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61",
-                "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3"
-            ],
-            "markers": "python_full_version >= '3.6.2'",
-            "version": "==22.1.0"
-        },
         "bleach": {
             "hashes": [
                 "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da",
@@ -155,6 +126,22 @@
                 "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
             ],
             "version": "==1.4"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:334f14ffbd89ddd15090e90b32e4fcea73d83b60b19ca2737a9264fd44096f35",
+                "sha256:a56e34d8dc3390006a6d7ae5373f357917932045e874c82de2736f3b42c02b10"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.21.22"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:92ba8afeda48f5d2467811d87df401d703a25191f82882994d8d09a7d8b5b965",
+                "sha256:e812604653c635c78431b3dd168d3fc04e8c3514839226814c999336d5e59ea0"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.24.22"
         },
         "cachelib": {
             "hashes": [
@@ -665,6 +652,14 @@
             ],
             "version": "==2.4.15"
         },
+        "fsspec": {
+            "hashes": [
+                "sha256:20322c659538501f52f6caa73b08b2ff570b7e8ea30a86559721d090e473ad5c",
+                "sha256:eb9c9d9aee49d23028deefffe53e87c55d3515512c63f57e893710301001449a"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2022.2.0"
+        },
         "ftfy": {
             "hashes": [
                 "sha256:3c0066db64a98436e751e56414f03f1cdea54f29364c0632c141c36cca6a5d94"
@@ -675,7 +670,7 @@
             "hashes": [
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.18.2"
         },
         "geojson": {
@@ -781,7 +776,8 @@
         "invenio-app-rdm": {
             "extras": [
                 "elasticsearch7",
-                "postgresql"
+                "postgresql",
+                "s3"
             ],
             "hashes": [
                 "sha256:07d6748fcf927087af61f30029a7d5ebaa447abab52a7d862b9756f2e69bad06",
@@ -1012,6 +1008,13 @@
             ],
             "version": "==1.2.8"
         },
+        "invenio-s3": {
+            "hashes": [
+                "sha256:81646647ad1a9fe1678921c6b7c6f4777f2fcdcf23bcaaf6043460d114663cdc",
+                "sha256:e8021c21e32f0101934edb959e9f353019a90eb1cbeba4b7da3a9a1b1ed68fdc"
+            ],
+            "version": "==1.0.6"
+        },
         "invenio-search": {
             "extras": [
                 "elasticsearch7"
@@ -1052,11 +1055,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:ab564d4521ea8ceaac26c3a2c6e5ddbca15c8848fd5a5cc325f960da88d42974",
-                "sha256:c503a0dd6ccac9c8c260b211f2dd4479c042b49636b097cc9a0d55fe62dff64c"
+                "sha256:6f56bfaeaa3247aa3b9cd3b8cbab3a9c0abf7428392f97b21902d12b2f42a381",
+                "sha256:8138762243c9b3a3ffcf70b37151a2a35c23d3a29f9743878c33624f4207be3d"
             ],
             "index": "pypi",
-            "version": "==8.0.1"
+            "version": "==8.1.1"
         },
         "isbnlib": {
             "hashes": [
@@ -1088,6 +1091,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.0.3"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:a490e280edd1f57d6de88636992d05b71e97d69a26a19f058ecf7d304474bf5e",
+                "sha256:e8dcd576ed616f14ec02eed0005c85973b5890083313860136657e24784e4c04"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.0"
         },
         "jsmin": {
             "hashes": [
@@ -1410,13 +1421,6 @@
             ],
             "version": "==1.0.3"
         },
-        "mypy-extensions": {
-            "hashes": [
-                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
-            ],
-            "version": "==0.4.3"
-        },
         "nbconvert": {
             "extras": [
                 "execute"
@@ -1488,13 +1492,6 @@
             ],
             "version": "==1.7.4"
         },
-        "pathspec": {
-            "hashes": [
-                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
-                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
-            ],
-            "version": "==0.9.0"
-        },
         "pexpect": {
             "hashes": [
                 "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
@@ -1550,14 +1547,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==9.0.1"
-        },
-        "platformdirs": {
-            "hashes": [
-                "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d",
-                "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.5.1"
         },
         "pluggy": {
             "hashes": [
@@ -1734,15 +1723,15 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.2"
         },
         "pytz": {
             "hashes": [
-                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
-                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
+                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
+                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
             ],
-            "version": "==2021.3"
+            "version": "==2022.1"
         },
         "pywebpack": {
             "hashes": [
@@ -1871,15 +1860,31 @@
             ],
             "version": "==1.1.0"
         },
+        "s3fs": {
+            "hashes": [
+                "sha256:2ca5de8dc18ad7ad350c0bd01aef0406aa5d0fff78a561f0f710f9d9858abdd0",
+                "sha256:91c1dfb45e5217bd441a7a560946fe865ced6225ff7eb0fb459fe6e601a95ed3"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.4.2"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971",
+                "sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.5.2"
+        },
         "sentry-sdk": {
             "extras": [
                 "flask"
             ],
             "hashes": [
-                "sha256:411a8495bd18cf13038e5749e4710beb4efa53da6351f67b4c2f307c2d9b6d49",
-                "sha256:aa52da941c56b5a76fd838f8e9e92a850bf893a9eb1e33ffce6c21431d07ee30"
+                "sha256:32af1a57954576709242beb8c373b3dbde346ac6bd616921def29d68846fb8c3",
+                "sha256:38fd16a92b5ef94203db3ece10e03bdaa291481dd7e00e77a148aa0302267d47"
             ],
-            "version": "==1.5.7"
+            "version": "==1.5.8"
         },
         "setuptools": {
             "hashes": [
@@ -1953,7 +1958,7 @@
                 "sha256:f63600ec06982cdf480899026f4fda622776f5fabed9a869fdb32d72bc17e99a",
                 "sha256:fb62d517a516128bacf08cb6a86ecd39fb06d08e7c4980251f5d5601d29989ba"
             ],
-            "markers": "python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==3.17.6"
         },
         "simplekv": {
@@ -1969,7 +1974,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "speaklater": {
@@ -2053,14 +2058,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.1.1"
-        },
-        "tomli": {
-            "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.1"
         },
         "tornado": {
             "hashes": [

--- a/assets/less/site/globals/site.overrides
+++ b/assets/less/site/globals/site.overrides
@@ -71,6 +71,7 @@ nav#invenio-nav {
   .section-title();
   margin-bottom: 30px;
   font-weight: 440;
+  padding-top: 3px;
 }
 
 .gkhub-frontpage-cards {

--- a/assets/less/site/globals/site.variables
+++ b/assets/less/site/globals/site.variables
@@ -20,3 +20,8 @@
 // ------------
 @footerLightColor: #397096;
 @footerDarkColor: @brandColor;
+
+// ------------
+// Links style
+// ------------
+@linkHoverUnderline: none;

--- a/assets/less/theme.config
+++ b/assets/less/theme.config
@@ -18,60 +18,60 @@
 */
 
 /* Global */
-@site        : 'invenio';
+@site        : 'rdm';
 @reset       : 'default';
 
 /* Elements */
-@button      : 'invenio';
-@container   : 'invenio';
-@divider     : 'default';
-@flag        : 'default';
-@header      : 'invenio';
+@button      : 'rdm';
+@container   : 'rdm';
+@divider     : 'rdm';
+@flag        : 'rdm';
+@header      : 'rdm';
 @icon        : 'default';
-@image       : 'default';
-@input       : 'invenio';
-@label       : 'default';
-@list        : 'default';
-@loader      : 'default';
-@placeholder : 'default';
-@rail        : 'default';
-@reveal      : 'default';
-@segment     : 'invenio';
-@step        : 'default';
+@image       : 'rdm';
+@input       : 'rdm';
+@label       : 'rdm';
+@list        : 'rdm';
+@loader      : 'rdm';
+@placeholder : 'rdm';
+@rail        : 'rdm';
+@reveal      : 'rdm';
+@segment     : 'rdm';
+@step        : 'rdm';
 
 /* Collections */
-@breadcrumb  : 'default';
-@form        : 'default';
-@grid        : 'default';
-@menu        : 'invenio';
-@message     : 'invenio';
-@table       : 'default';
+@breadcrumb  : 'rdm';
+@form        : 'rdm';
+@grid        : 'rdm';
+@menu        : 'rdm';
+@message     : 'rdm';
+@table       : 'rdm';
 
 /* Modules */
-@accordion   : 'default';
-@checkbox    : 'default';
-@dimmer      : 'default';
-@dropdown    : 'default';
-@embed       : 'default';
-@modal       : 'default';
-@nag         : 'default';
-@popup       : 'default';
-@progress    : 'default';
-@rating      : 'default';
-@search      : 'default';
-@shape       : 'default';
-@sidebar     : 'default';
-@sticky      : 'default';
-@tab         : 'default';
+@accordion   : 'rdm';
+@checkbox    : 'rdm';
+@dimmer      : 'rdm';
+@dropdown    : 'rdm';
+@embed       : 'rdm';
+@modal       : 'rdm';
+@nag         : 'rdm';
+@popup       : 'rdm';
+@progress    : 'rdm';
+@rating      : 'rdm';
+@search      : 'rdm';
+@shape       : 'rdm';
+@sidebar     : 'rdm';
+@sticky      : 'rdm';
+@tab         : 'rdm';
 @transition  : 'default';
 
 /* Views */
-@ad          : 'default';
-@card        : 'default';
-@comment     : 'default';
-@feed        : 'default';
-@item        : 'default';
-@statistic   : 'default';
+@ad          : 'rdm';
+@card        : 'rdm';
+@comment     : 'rdm';
+@feed        : 'rdm';
+@item        : 'rdm';
+@statistic   : 'rdm';
 
 /*******************************
             Folders

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -139,9 +139,12 @@ FILES_REST_STORAGE_FACTORY='invenio_s3.s3fs_storage_factory'
 
 # Invenio-S3
 # ==========
-S3_ENDPOINT_URL='http://localhost:9000/'
-S3_SECRET_ACCESS_KEY='CHANGE_ME'
+# See https://invenio-s3.readthedocs.io/en/latest/configuration.html
+S3_REGION_NAME='us-east-1'  # required when Amazon AWS is used.
 S3_ACCESS_KEY_ID='CHANGE_ME'
+S3_SECRET_ACCESS_KEY='CHANGE_ME'
+
+S3_ENDPOINT_URL='http://localhost:9000/'
 
 # Allow S3 endpoint in the CSP rules
 APP_DEFAULT_SECURE_HEADERS['content_security_policy']['default-src'].append(

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -20,12 +20,12 @@ from flask_babelex import lazy_gettext as _
 # SECURITY WARNING: keep the secret key used in production secret!
 # TODO: Set
 SECRET_KEY="CHANGE_ME"
+
 # Since HAProxy and Nginx route all requests no matter the host header
 # provided, the allowed hosts variable is set to localhost. In production it
 # should be set to the correct host and it is strongly recommended to only
 # route correct hosts to the application.
 APP_ALLOWED_HOSTS = ['0.0.0.0', 'localhost', '127.0.0.1']
-
 
 # Flask-SQLAlchemy
 # ================
@@ -89,9 +89,6 @@ I18N_LANGUAGES = [
 APP_THEME = ["semantic-ui"]
 """App theme"""
 
-BASE_TEMPLATE = "geo_knowledge_hub/base/page.html"
-"""Global base template."""
-
 THEME_FRONTPAGE_TITLE = "GEO Knowledge Hub"
 """Frontpage title."""
 
@@ -119,6 +116,19 @@ THEME_FRONTPAGE_TEMPLATE = "geo_knowledge_hub/frontpage/frontpage.html"
 # Invenio-App-RDM
 # ===============
 # See https://invenio-app-rdm.readthedocs.io/en/latest/configuration.html
+
+# Template names for detail view sidebar components
+APP_RDM_DETAIL_SIDE_BAR_TEMPLATES = [
+    "invenio_app_rdm/records/details/side_bar/manage_menu.html",
+    "invenio_app_rdm/records/details/side_bar/metrics.html",
+    "invenio_app_rdm/records/details/side_bar/versions.html",
+    "geo_knowledge_hub/records/details/side_bar/geospatial_metadata_visualizer.html",
+    "geo_knowledge_hub/records/details/side_bar/engagement_priorities.html",
+    "geo_knowledge_hub/records/details/side_bar/keywords_subjects.html",
+    "invenio_app_rdm/records/details/side_bar/details.html",
+    "invenio_app_rdm/records/details/side_bar/licenses.html",
+    "invenio_app_rdm/records/details/side_bar/export.html",
+]
 
 # Instance's theme entrypoint file. Path relative to the ``assets/`` folder.
 INSTANCE_THEME_FILE = './less/theme.less'
@@ -174,18 +184,19 @@ RDM_SEARCH = {
 # Invenio-RDM-Records
 # ===================
 # See https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/config.py
-RDM_RECORDS_DOI_DATACITE_ENABLED = True
-RDM_RECORDS_DOI_DATACITE_USERNAME = ""
-RDM_RECORDS_DOI_DATACITE_PASSWORD = ""
-RDM_RECORDS_DOI_DATACITE_PREFIX = "10.5072"
-RDM_RECORDS_DOI_DATACITE_TEST_MODE = True
+# See https://inveniordm.docs.cern.ch/releases/upgrading/upgrade-v7.0/#updating-configuration-variables
+DATACITE_ENABLED = True
+DATACITE_USERNAME = ""
+DATACITE_PASSWORD = ""
+DATACITE_PREFIX = "10.5072"
+DATACITE_TEST_MODE = True
 
 # Authentication - Invenio-Accounts and Invenio-OAuthclient
 # =========================================================
 # See: https://inveniordm.docs.cern.ch/customize/authentication/
 
 # Invenio-Accounts
-# ----------------
+# ===================
 # See https://github.com/inveniosoftware/invenio-accounts/blob/master/invenio_accounts/config.py
 ACCOUNTS_LOCAL_LOGIN_ENABLED = True  # enable local login
 SECURITY_REGISTERABLE = True  # local login: allow users to register
@@ -194,9 +205,8 @@ SECURITY_CHANGEABLE = True  # local login: allow users to change psw
 SECURITY_CONFIRMABLE = True  # require users to confirm e-mail address
 
 # Invenio-OAuthclient
-# -------------------
+# ===================
 # See https://github.com/inveniosoftware/invenio-oauthclient/blob/master/invenio_oauthclient/config.py
-
 OAUTHCLIENT_REMOTE_APPS = {}  # configure external login providers
 
 from invenio_oauthclient.views.client import auto_redirect_login
@@ -204,7 +214,7 @@ ACCOUNTS_LOGIN_VIEW_FUNCTION = auto_redirect_login  # autoredirect to external l
 OAUTHCLIENT_AUTO_REDIRECT_TO_EXTERNAL_LOGIN = False  # autoredirect to external login
 
 # Invenio-UserProfiles
-# --------------------
+# ===================
 USERPROFILES_READ_ONLY = False  # allow users to change profile info (name, email, etc...)
 
 # Invenio-Communities
@@ -250,3 +260,10 @@ DISCUSSION_ISSO_MAX_COMMENTS_NESTED = 2
 """Isso commenting client configurations (GEO Default)"""
 
 ## See more Flask-Discussion options for Isso at: https://flask-discussion.readthedocs.io/en/latest/configs/isso.html
+
+# Flask Limiter
+# ===================
+# See https://flask-limiter.readthedocs.io/en/stable/
+RATELIMIT_GUEST_USER = "5000 per hour;500 per minute"
+
+RATELIMIT_AUTHENTICATED_USER = "25000 per hour;1000 per minute"


### PR DESCRIPTION
This commit upgrades the GEO Knowledge Hub runtime to InvenioRDM version 8.0. Along with this PR, validations were performed with our InvenioRDM modules. The necessary changes are being made in the respective repositories.

With this version change, the following modules will change:

- [geo-knowledge-hub](https://github.com/geo-knowledge-hub/geo-knowledge-hub);
- [geo-vocabularies](https://github.com/geo-knowledge-hub/geo-vocabularies).